### PR TITLE
[AI-03] Security: fix permission issues - dogeow-api - 2026-03-20

### DIFF
--- a/app/Http/Controllers/Api/Note/NoteController.php
+++ b/app/Http/Controllers/Api/Note/NoteController.php
@@ -355,6 +355,21 @@ class NoteController extends Controller
             'type' => 'nullable|string|max:255',
         ]);
 
+        $userId = $this->getCurrentUserId();
+        $user = \Illuminate\Support\Facades\Auth::user();
+
+        $sourceNote = \App\Models\Note\Note::find($validated['source_id']);
+        $targetNote = \App\Models\Note\Note::find($validated['target_id']);
+
+        // Authorization: user must own at least one of the notes (or be admin) to create a link between them
+        $canCreateLink = $user->isAdmin()
+            || $sourceNote->user_id === $userId
+            || $targetNote->user_id === $userId;
+
+        if (! $canCreateLink) {
+            return $this->error('You do not have permission to create a link for these notes', [], 403);
+        }
+
         // 检查是否已存在相同的链接
         $existingLink = NoteLink::where('source_id', $validated['source_id'])
             ->where('target_id', $validated['target_id'])
@@ -381,7 +396,15 @@ class NoteController extends Controller
      */
     public function destroyLink(int $id): JsonResponse
     {
-        $link = NoteLink::findOrFail($id);
+        $link = NoteLink::with('sourceNote')->findOrFail($id);
+        $userId = $this->getCurrentUserId();
+        $user = \Illuminate\Support\Facades\Auth::user();
+
+        // Authorization: only the owner of the source note (or admin) can delete the link
+        if (! $user->isAdmin() && $link->sourceNote?->user_id !== $userId) {
+            return $this->error('You do not have permission to delete this link', [], 403);
+        }
+
         $link->delete();
 
         return $this->success([], 'Link deleted successfully');

--- a/tests/Feature/NoteControllerTest.php
+++ b/tests/Feature/NoteControllerTest.php
@@ -863,4 +863,125 @@ class NoteControllerTest extends TestCase
             ->assertJsonPath('is_wiki', true)
             ->assertJsonPath('slug', 'auto-generated-slug-wiki');
     }
+
+    // ─── Link Authorization Tests ─────────────────────────────────────────────
+
+    public function test_store_link_allows_user_who_owns_source_note(): void
+    {
+        $source = Note::factory()->create(['user_id' => $this->user->id]);
+        $otherUser = User::factory()->create();
+        $target = Note::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->postJson('/api/notes/links', [
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_store_link_allows_user_who_owns_target_note(): void
+    {
+        $otherUser = User::factory()->create();
+        $source = Note::factory()->create(['user_id' => $otherUser->id]);
+        $target = Note::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->postJson('/api/notes/links', [
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_store_link_denies_user_who_owns_neither_note(): void
+    {
+        $otherUser = User::factory()->create();
+        $source = Note::factory()->create(['user_id' => $otherUser->id]);
+        $target = Note::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->postJson('/api/notes/links', [
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'You do not have permission to create a link for these notes']);
+    }
+
+    public function test_store_link_allows_admin_regardless_of_ownership(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        Sanctum::actingAs($admin);
+
+        $otherUser = User::factory()->create();
+        $source = Note::factory()->create(['user_id' => $otherUser->id]);
+        $target = Note::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->postJson('/api/notes/links', [
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_destroy_link_allows_owner_of_source_note(): void
+    {
+        $source = Note::factory()->create(['user_id' => $this->user->id]);
+        $target = Note::factory()->create(['user_id' => $this->user->id]);
+
+        $link = NoteLink::create([
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response = $this->deleteJson("/api/notes/links/{$link->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('note_links', ['id' => $link->id]);
+    }
+
+    public function test_destroy_link_denies_user_who_does_not_own_source_note(): void
+    {
+        $otherUser = User::factory()->create();
+        $source = Note::factory()->create(['user_id' => $otherUser->id]);
+        $target = Note::factory()->create(['user_id' => $this->user->id]);
+
+        $link = NoteLink::create([
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response = $this->deleteJson("/api/notes/links/{$link->id}");
+
+        $response->assertStatus(403)
+            ->assertJson(['message' => 'You do not have permission to delete this link']);
+    }
+
+    public function test_destroy_link_allows_admin_regardless_of_ownership(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        Sanctum::actingAs($admin);
+
+        $otherUser = User::factory()->create();
+        $source = Note::factory()->create(['user_id' => $otherUser->id]);
+        $target = Note::factory()->create(['user_id' => $otherUser->id]);
+
+        $link = NoteLink::create([
+            'source_id' => $source->id,
+            'target_id' => $target->id,
+            'type' => 'related',
+        ]);
+
+        $response = $this->deleteJson("/api/notes/links/{$link->id}");
+
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
## Summary

### Security Fixes Applied

Fixed **2 IDOR (Insecure Direct Object Reference) vulnerabilities** in the Note controller:

#### 1.  — Missing Authorization (HIGH)
- **Before**: Any authenticated user could create links between ANY notes without owning them
- **After**: User must own at least one of the source/target notes, or be an admin
- **CVSS**: 6.5 (Medium)

#### 2.  — Missing Authorization (HIGH)
- **Before**: Any authenticated user could delete ANY note link
- **After**: Only the source note owner (or admin) can delete a link
- **CVSS**: 6.5 (Medium)

### Additional Observations (Design Notes)

- ** always returns **: The  has a TODO comment and always returns . Room creators can still moderate their own rooms through , so actual moderation functionality is not broken — but proper moderator role support needs separate implementation.
- **Wiki nodes () are editable by any authenticated user**: This is intentional for the collaborative wiki use case, bypassing the  admin check. Not a vulnerability, but worth documenting.

### Tests Added

7 new authorization tests in :
- 
- 
- 
- 
- 
- 
- 

### Files Changed

-  — Added authorization checks to  and 
-  — Added 7 authorization tests